### PR TITLE
only depend on unix_socket on unix targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,10 @@ semver = "^0.2.1"
 rand = "^0.3.13"
 conhash = "^0.3.0"
 log = "^0.3.4"
-unix_socket = "^0.5.0"
 bufstream = "^0.1.1"
+
+[target.'cfg(unix)'.dependencies]
+unix_socket = "^0.5.0"
 
 [dev-dependencies]
 env_logger = "*"


### PR DESCRIPTION
When attempting to integrate in another project that targets Windows, [a CI failure was encountered](https://ci.appveyor.com/project/luser/sccache2/build/1.0.393/job/h2w4jjetuxjgfoob).
With this change, the [CI job passes](https://ci.appveyor.com/project/luser/sccache2/build/1.0.394/job/6o3y0nhtf9lb6gpx).