### PR TITLE
Disable Nagle's algorithm to reduce latency

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -40,6 +40,7 @@ impl Server {
                 proto::ProtoType::Binary => match (split.next(), split.next()) {
                     (Some("tcp"), Some(addr)) => {
                         let stream = TcpStream::connect(addr)?;
+                        stream.set_nodelay(true)?;
                         Box::new(proto::BinaryProto::new(BufStream::new(stream))) as Box<Proto + Send>
                     }
                     #[cfg(unix)]


### PR DESCRIPTION
When a command (or part of a command) is much smaller than the network MTU, a (well-known) problem occurs between delayed ACKs and Nagle's algorithm. Specifically, Nagle tries to maximize packet size, and will avoid sending a non-full packet unless there are no currently unacked packets. Delayed ACKs delays sending ACKs to (again) minimize the number of packets sent over the network, and instead coalesce many ACKs over a prolonged period of time. When sending small messages, these interact poorly: Nagle will effectively not let you send a packet until the delayed ACK timeout expires on the other host.

The standard dictates that the delayed ACK timeout is at most 500ms, but in Linux, the actual delays are dictated by [`TCP_DELACK_MIN/MAX`](https://elixir.bootlin.com/linux/latest/ident/TCP_DELACK_MIN), and the minimum is usually set to 40ms. These 40ms will appear as an artificial delay to some commands, without the server or client doing any useful work.

This commit sets `TCP_NODELAY` on TCP connections, which turns off Nagle's algorithm. This comes at a small throughput cost, but significantly reduces latency.

See also https://github.com/blackbeam/rust-mysql-simple/pull/134.