### PR TITLE
Make connection interface more flexible

### DIFF
--- a/examples/sasl.rs
+++ b/examples/sasl.rs
@@ -4,7 +4,7 @@ use memcached::proto::{Operation, ProtoType};
 use memcached::Client;
 
 fn main() {
-    let servers = [("tcp://my-sasl-memcached-server.com:11211", 1)];
+    let servers: Vec<(String, usize)> = [("tcp://my-sasl-memcached-server.com:11211", 1)].iter().map(|(s,i)| (s.to_string(), *i)).collect();
     let mut client = Client::connect_sasl(&servers, ProtoType::Binary, "my-username", "my-password").unwrap();
 
     client.set(b"Foo", b"Bar", 0xdeadbeef, 2).unwrap();


### PR DESCRIPTION
This allows `[(&str,usize)]` or `[(String, usize)]` to be passed to `connect` and `connect_sasl` which makes life a lot easier!

Work was actually done by @alevy