### PR TITLE
Refactor protocol implementation by using crate bytes and fastrand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ nightly = []
 [dependencies]
 byteorder = "1.2"
 semver = "0.9"
-rand = "0.7"
+fastrand = "1.3"
 conhash = "0.4"
 log = "0.4"
 bufstream = "0.1"
+bytes = "0.5"
 
 [target.'cfg(unix)'.dependencies]
 unix_socket = "0.5"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -489,11 +489,10 @@ impl MultiOperation for Client {
 mod test {
     use super::Client;
     use crate::proto::{NoReplyOperation, Operation, ProtoType};
-    use rand::random;
     use test::Bencher;
 
     fn generate_data(len: usize) -> Vec<u8> {
-        (0..len).map(|_| random()).collect()
+        (0..len).map(|_| fastrand::u8(..)).collect()
     }
 
     #[bench]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -14,6 +14,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::io;
 use std::net::TcpStream;
 use std::ops::Deref;
+use std::path::Path;
 use std::rc::Rc;
 
 use conhash::{ConsistentHash, Node};

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -14,7 +14,6 @@ use std::collections::{BTreeMap, HashMap};
 use std::io;
 use std::net::TcpStream;
 use std::ops::Deref;
-use std::path::Path;
 use std::rc::Rc;
 
 use conhash::{ConsistentHash, Node};
@@ -170,7 +169,7 @@ impl Client {
         Ok(Client { servers })
     }
 
-    fn find_server_by_key<'a>(&'a mut self, key: &[u8]) -> &'a mut ServerRef {
+    fn find_server_by_key(&mut self, key: &[u8]) -> &mut ServerRef {
         self.servers.get_mut(key).expect("No valid server found")
     }
 }


### PR DESCRIPTION
Replace `rand` with `fastrand` which is smaller and faster.

Replace `Vec<u8>` in `RequestPacket` and `ResponsePacket` with `Bytes` in crate [bytes](https://github.com/tokio-rs/bytes).
> Bytes is an efficient container for storing and operating on contiguous slices of memory.

By using it, we can allocate a block of memory then split it to 3 slices instead of 3 individual allocation.
The drawback is `Bytes` can't grow up in place. And the current public APIs isn't changed yet, there's still `Vec<u8>` creation which is inefficient. I think it's worth to return `Bytes` directly to users, if they want to resize it they could turn it into  `Vec<u8>`.